### PR TITLE
Resolve dependency issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ samplotlib==0.0.6
 emcee==3.1.4
 transformers==4.31.0
 openai==0.27.7
-fschat==0.2.20
+fschat==0.2.23
 peft @ git+https://github.com/huggingface/peft.git@b1059b73aab9043b118ff19b0cf96263ea86248a
 fire==0.5.0
 shortuuid==1.0.11
@@ -11,3 +11,4 @@ matplotlib
 numpy
 pandas
 getdist
+anthropic


### PR DESCRIPTION
This commit includes fixes for a couple of following dependency issues

- fschat>=0.2.23
  - systemp_prompt variable, which is used in common.py, of Conversation class in
    fschat==0.2.20 is not available, >= 0.2.23 was required. (*1)
  - fschat==0.2.20 is incompatible with transformers==4.31.0 but >=0.2.23 is applicable.

- anthropic
  - common.py and gen_api_answer.py imports anthoropic but not appeared in requirements.txt yet.

Related to https://github.com/yuzu-ai/japanese-llm-ranking/issues/11

1: https://github.com/lm-sys/FastChat/commit/c1e38c3829b3e9609589c41e85201dc4730e00f2